### PR TITLE
feat: optimize PhotoDeck for mobile devices

### DIFF
--- a/src/hooks/useScreenSize.ts
+++ b/src/hooks/useScreenSize.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface ScreenSize {
+  isMobile: boolean;
+  isPortrait: boolean;
+}
+
+// Match Tailwind CSS sm breakpoint (640px)
+// Reference: https://tailwindcss.com/docs/responsive-design
+const MOBILE_BREAKPOINT = 640;
+
+export function useScreenSize(): ScreenSize {
+  const [screenSize, setScreenSize] = useState<ScreenSize>({
+    isMobile: false,
+    isPortrait: false,
+  });
+
+  useEffect(() => {
+    const updateScreenSize = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      setScreenSize({
+        isMobile: width < MOBILE_BREAKPOINT, // < 600px = mobile
+        isPortrait: height > width,           // orientation: portrait
+      });
+    };
+
+    // Initial check
+    updateScreenSize();
+
+    // Listen for resize and orientation changes
+    window.addEventListener('resize', updateScreenSize);
+    window.addEventListener('orientationchange', updateScreenSize);
+
+    return () => {
+      window.removeEventListener('resize', updateScreenSize);
+      window.removeEventListener('orientationchange', updateScreenSize);
+    };
+  }, []);
+
+  return screenSize;
+}

--- a/src/lib/api/services/photos.ts
+++ b/src/lib/api/services/photos.ts
@@ -31,6 +31,8 @@ export interface PhotosService {
   getPhotoThumbUrl(id: string): string;
   getPhotoResizeUrl(id: string): string;
   getPhotoUrl(id: string): string;
+  getPhotoAspect(photo: PhotoMetadata): 'portrait' | 'landscape' | 'square';
+  getDynamicImageUrl(photo: PhotoMetadata, isPortrait: boolean, isMobile: boolean): string;
 }
 
 export const photosService: PhotosService = {
@@ -136,5 +138,30 @@ export const photosService: PhotosService = {
 
   getPhotoUrl(id: string) {
     return API_ENDPOINTS.photoFile(id);
+  },
+
+  getPhotoAspect(photo: PhotoMetadata): 'portrait' | 'landscape' | 'square' {
+    const ratio = photo.width / photo.height;
+    if (ratio >= 1.25) return 'landscape';
+    if (ratio >= 0.8) return 'square';
+    return 'portrait';
+  },
+
+  getDynamicImageUrl(photo: PhotoMetadata, isPortrait: boolean, isMobile: boolean): string {
+    // Desktop: use full quality photo
+    if (!isMobile) {
+      return this.getPhotoUrl(photo.id);
+    }
+
+    // Mobile portrait: use portrait or square crop based on photo aspect
+    if (isPortrait) {
+      const aspect = this.getPhotoAspect(photo);
+      return aspect === 'portrait'
+        ? this.getPortraitUrl(photo.id)
+        : this.getSquareUrl(photo.id);
+    }
+
+    // Mobile landscape: use landscape crop
+    return this.getLandscapeUrl(photo.id);
   },
 }; 


### PR DESCRIPTION
## Summary

Optimizes PhotoDeck component for mobile devices by implementing dynamic image selection based on screen size and orientation. This improves mobile UX by maximizing screen space and reducing bandwidth usage through appropriately sized image crops.

**Key improvements:**
- Mobile devices (< 640px) now use portrait/landscape/square cropped images instead of full-quality photos
- Images fill the entire screen on mobile with zero padding
- Edit controls display horizontally on all screen sizes to prevent overlap with navigation buttons
- Desktop behavior preserved with no visual changes

**Technical changes:**
- Added `useScreenSize` hook to detect mobile devices (640px breakpoint, aligned with Tailwind CSS `sm`)
- Added photo aspect ratio detection using same thresholds as old mphotos-web (portrait < 0.8, square 0.8-1.25, landscape >= 1.25)
- Added `getDynamicImageUrl` method to photos service for intelligent image crop selection
- Updated PhotoDeck to use dynamic images on mobile while maintaining full quality on desktop

## Test Plan

- [ ] Test on mobile portrait mode (< 640px width)
  - [ ] Verify images fill screen edge-to-edge
  - [ ] Verify correct crop used (portrait for portrait photos, square for landscape photos)
  - [ ] Verify edit controls display horizontally without overlapping navigation
  - [ ] Verify photo metadata visible without excessive scrolling

- [ ] Test on mobile landscape mode
  - [ ] Verify landscape crop used
  - [ ] Verify edit controls don't overlap with prev/next buttons

- [ ] Test on desktop (> 640px width)
  - [ ] Verify full-quality images used
  - [ ] Verify no visual changes from current production
  - [ ] Verify proper spacing/borders with different UX settings (none/left-right/all)

- [ ] Test various photo aspect ratios
  - [ ] Portrait photos (< 0.8 ratio)
  - [ ] Square photos (0.8-1.25 ratio)
  - [ ] Landscape photos (>= 1.25 ratio)

- [ ] Test navigation between photos on mobile and desktop