### PR TITLE
Remove debug console.log calls from usePhotos

### DIFF
--- a/src/hooks/usePhotos.ts
+++ b/src/hooks/usePhotos.ts
@@ -17,7 +17,6 @@ export function usePhotos() {
 
     try {
       setIsLoading(true);
-      console.log('Loading photos, isUser:', isUser, 'photoStreamAlbumId:', uxConfig.photoStreamAlbumId);
       
       let newPhotos: PhotoMetadata[];
       if (isUser) {
@@ -33,14 +32,10 @@ export function usePhotos() {
         newPhotos = albumPhotoList.photos;
       }
       
-      console.log('Received photos:', newPhotos);
-      
       // Filter out duplicates
       const uniqueNewPhotos = newPhotos.filter(
         (newPhoto) => !photos.some((existingPhoto) => existingPhoto.id === newPhoto.id)
       );
-      console.log('Unique new photos:', uniqueNewPhotos);
-      
       setPhotos((prev) => [...prev, ...uniqueNewPhotos]);
       setHasMore(uniqueNewPhotos.length > 0);
     } catch (error) {
@@ -52,7 +47,6 @@ export function usePhotos() {
   }, [photos, isUser, uxConfig.photoStreamAlbumId, isConfigLoading]);
 
   const refresh = useCallback(async () => {
-    console.log('Refreshing photos');
     setPhotos([]);
     setHasMore(true);
     await loadPhotos();


### PR DESCRIPTION
## Janitor Agent - Remove debug console.log calls from usePhotos

Several console.log statements in usePhotos.ts are leftover debug output that were never cleaned up. They log internal state transitions and raw API responses on every photo load, cluttering the browser console in production.

### Changes

- src/hooks/usePhotos.ts: Remove all four console.log calls: 'Loading photos, isUser:...' (line 21), 'Received photos:...' (line 32 approx), 'Unique new photos:...' (line ~38), and 'Refreshing photos' (line ~41 in refresh callback)

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*