### PR TITLE
Replace duplicate Colors constant with shared lib/colors import

### DIFF
--- a/src/components/account/UxConfig.tsx
+++ b/src/components/account/UxConfig.tsx
@@ -12,15 +12,7 @@ import { RadioGroup } from '@/components/RadioGroup';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { Button } from '@/components/Button';
 import { useToast } from '@/context/ToastContext';
-
-// Color constants matching the old implementation
-const Colors = {
-  White: '#ffffff',
-  Light: '#fafafa',
-  Grey: '#bdbdbd',
-  Dark: '#303030',
-  Black: '#121212',  // Match dark theme background
-};
+import { Colors } from '@/lib/colors';
 
 const gridSpacings = [
   { value: '0', label: 'None' },


### PR DESCRIPTION
## Janitor Agent - Replace duplicate Colors constant with shared lib/colors import

UxConfig.tsx defines its own local Colors object that duplicates the Colors enum already exported from src/lib/colors.ts. Using the shared enum eliminates the duplication and ensures color values stay in sync.

### Changes

- src/components/account/UxConfig.tsx: Remove the local `const Colors = { ... }` block and instead import `Colors` from '@/lib/colors'. Update the RadioGroup options to use `Colors.White`, `Colors.Light`, `Colors.Grey`, `Colors.Dark`, `Colors.Black` (the enum values are identical hex strings).

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*