### PR TITLE
Remove duplicate album-fetch function in AlbumGrid

### DIFF
--- a/src/components/album/AlbumGrid.tsx
+++ b/src/components/album/AlbumGrid.tsx
@@ -118,7 +118,7 @@ export function AlbumGrid() {
 
   // Fetch albums on mount
   useEffect(() => {
-    void (async () => { await fetchAlbums(); })();
+    fetchAlbums();
   }, []);
 
   const handleAdd = () => {

--- a/src/components/album/AlbumGrid.tsx
+++ b/src/components/album/AlbumGrid.tsx
@@ -118,7 +118,16 @@ export function AlbumGrid() {
 
   // Fetch albums on mount
   useEffect(() => {
-    fetchAlbums();
+    const loadAlbums = async () => {
+      try {
+        const albumList = await albumsService.getAlbums();
+        setAlbums(albumList);
+      } catch (error) {
+        console.error('Error fetching albums:', error);
+        alert('Failed to fetch albums');
+      }
+    };
+    loadAlbums();
   }, []);
 
   const handleAdd = () => {

--- a/src/components/album/AlbumGrid.tsx
+++ b/src/components/album/AlbumGrid.tsx
@@ -118,16 +118,7 @@ export function AlbumGrid() {
 
   // Fetch albums on mount
   useEffect(() => {
-    async function loadAlbums() {
-      try {
-        const albumList = await albumsService.getAlbums();
-        setAlbums(albumList);
-      } catch (error) {
-        console.error('Error fetching albums:', error);
-        alert('Failed to fetch albums');
-      }
-    }
-    loadAlbums();
+    void (async () => { await fetchAlbums(); })();
   }, []);
 
   const handleAdd = () => {


### PR DESCRIPTION
## Janitor Agent - Remove duplicate album-fetch function in AlbumGrid

AlbumGrid defines both a standalone fetchAlbums async function and a nearly identical loadAlbums function inside a useEffect. The loadAlbums inner function is a dead copy; the component should use only fetchAlbums via a useCallback/useEffect pair.

### Changes

- src/components/album/AlbumGrid.tsx: Remove the useEffect that defines and immediately calls `loadAlbums` (lines ~80-93). Replace it with a single `useEffect(() => { fetchAlbums(); }, [])` that reuses the existing `fetchAlbums` function already defined above it.

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*