### PR TITLE
Rename ApiError interface to avoid clash with ApiError class

### DIFF
--- a/src/lib/api/types/index.ts
+++ b/src/lib/api/types/index.ts
@@ -128,14 +128,14 @@ export interface Config {
   driveConfigured: boolean;
 }
 
-export interface ApiError {
+export interface ApiErrorBody {
   status: number;
   message: string;
 }
 
 export type ApiResponse<T> = {
   data?: T;
-  error?: ApiError;
+  error?: ApiErrorBody;
 }
 
 export interface AuthUser {


### PR DESCRIPTION
## Janitor Agent - Rename ApiError interface to avoid clash with ApiError class

src/lib/api/types/index.ts exports an `ApiError` interface and src/lib/api/client.ts exports an `ApiError` class with the same name. Any file importing both will have a name collision. The interface in types should be renamed to `ApiErrorBody` (or similar) since it represents the error payload shape, not the thrown error.

### Changes

- src/lib/api/types/index.ts: Rename the `ApiError` interface to `ApiErrorBody`. Update the `ApiResponse<T>` type on the lines below it that references `error?: ApiError` to use `error?: ApiErrorBody`.

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*