### PR TITLE
Remove no-op try/catch in MPContext login

### DIFF
--- a/src/context/MPContext.tsx
+++ b/src/context/MPContext.tsx
@@ -183,12 +183,8 @@ export const MPContextProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   };
 
   const login = async (password: string) => {
-    try {
-      await authService.login(password);
-      await refreshAuth();
-    } catch (error) {
-      throw error;
-    }
+    await authService.login(password);
+    await refreshAuth();
   };
 
   const logout = async () => {


### PR DESCRIPTION
## Janitor Agent - Remove no-op try/catch in MPContext login

The `login` function in `MPContext.tsx` wraps `authService.login` in a try/catch that immediately re-throws the error without any handling, transformation, or logging. This is dead code that adds noise without benefit.

### Changes

- src/context/MPContext.tsx: In the `login` async function, remove the outer `try/catch` block that only calls `await authService.login(password)` and re-throws in the catch. Simplify the body to directly call `await authService.login(password); await refreshAuth();` without wrapping in try/catch (callers already handle errors).

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*