### PR TITLE
Replace alert() with useToast in error handlers

### DIFF
--- a/src/components/account/GoogleDrive.tsx
+++ b/src/components/account/GoogleDrive.tsx
@@ -70,7 +70,7 @@ export function GoogleDrive() {
       await userService.updateUserGDrive(folderName);
       await refreshAuth();
     } catch (error) {
-      toast.error('Error setting folder');
+      toast.error('Error setting folder: ' + error);
     }
   };
 
@@ -96,7 +96,7 @@ export function GoogleDrive() {
       }
     } catch (error) {
       console.error('Error starting download:', error);
-      toast.error('Error starting download');
+      toast.error('Error starting download: ' + error);
     }
   };
 
@@ -114,7 +114,7 @@ export function GoogleDrive() {
         setAuthenticated(false);
       } catch (error) {
         console.error('Error disconnecting:', error);
-        toast.error('Error disconnecting');
+        toast.error('Error disconnecting: ' + error);
       }
     } else {
       // Connect - redirect to auth URL

--- a/src/components/account/GoogleDrive.tsx
+++ b/src/components/account/GoogleDrive.tsx
@@ -70,7 +70,7 @@ export function GoogleDrive() {
       await userService.updateUserGDrive(folderName);
       await refreshAuth();
     } catch (error) {
-      toast.error('Error setting folder: ' + error);
+      toast.error('Error setting folder');
     }
   };
 
@@ -96,7 +96,7 @@ export function GoogleDrive() {
       }
     } catch (error) {
       console.error('Error starting download:', error);
-      toast.error('Error starting download: ' + error);
+      toast.error('Error starting download');
     }
   };
 
@@ -114,7 +114,7 @@ export function GoogleDrive() {
         setAuthenticated(false);
       } catch (error) {
         console.error('Error disconnecting:', error);
-        toast.error('Error disconnecting: ' + error);
+        toast.error('Error disconnecting');
       }
     } else {
       // Connect - redirect to auth URL

--- a/src/components/account/GoogleDrive.tsx
+++ b/src/components/account/GoogleDrive.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { driveService } from '@/lib/api/services';
 import { userService } from '@/lib/api/services';
+import { useToast } from '@/context/ToastContext';
 import { Button } from '@/components/Button';
 import { TextField } from '@/components/TextField';
 import { useMPContext } from '@/context/MPContext';
@@ -13,6 +14,7 @@ const AUTH_URL = '/api/drive/auth?redir=' + encodeURIComponent('/account');
 
 export function GoogleDrive() {
   const { user, refreshAuth } = useMPContext();
+  const toast = useToast();
   const [authenticated, setAuthenticated] = useState<boolean | null>(null);
   const [folderName, setFolderName] = useState(user.driveFolderName || '');
   const [folderId, setFolderId] = useState(user.driveFolderId || '');
@@ -52,7 +54,7 @@ export function GoogleDrive() {
           setIsDownloading(false);
         } else if (updatedJob.state === JobState.ABORTED) {
           setIsDownloading(false);
-          alert('Job aborted: ' + (updatedJob.error || 'Unknown error'));
+          toast.warning('Job aborted: ' + (updatedJob.error || 'Unknown error'));
         }
       } catch (error) {
         console.error('Error checking job status:', error);
@@ -68,7 +70,7 @@ export function GoogleDrive() {
       await userService.updateUserGDrive(folderName);
       await refreshAuth();
     } catch (error) {
-      alert('Error setting folder: ' + error);
+      toast.error('Error setting folder');
     }
   };
 
@@ -90,11 +92,11 @@ export function GoogleDrive() {
         setJob(newJob);
         setIsDownloading(true);
       } else {
-        alert('Unexpected job state: ' + newJob.state);
+        toast.error('Unexpected job state: ' + newJob.state);
       }
     } catch (error) {
       console.error('Error starting download:', error);
-      alert('Error starting download: ' + error);
+      toast.error('Error starting download');
     }
   };
 
@@ -112,7 +114,7 @@ export function GoogleDrive() {
         setAuthenticated(false);
       } catch (error) {
         console.error('Error disconnecting:', error);
-        alert('Error disconnecting: ' + error);
+        toast.error('Error disconnecting');
       }
     } else {
       // Connect - redirect to auth URL

--- a/src/components/account/Maintenance.tsx
+++ b/src/components/account/Maintenance.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect } from 'react';
 import { photosService } from '@/lib/api/services';
 import { Button } from '@/components/Button';
 import { Dialog } from '@/components/Dialog';
+import { useToast } from '@/context/ToastContext';
 
 export function Maintenance() {
+  const toast = useToast();
   const [photoCount, setPhotoCount] = useState<number>(0);
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -21,7 +23,7 @@ export function Maintenance() {
     setDeleting(true);
     try {
       const result = await photosService.deletePhotos(true);
-      alert(`Successfully deleted ${result.length} photos`);
+      toast.success(`Successfully deleted ${result.length} photos`);
       setPhotoCount(0);
       setOpenDeleteDialog(false);
     } catch (error) {

--- a/src/components/account/Maintenance.tsx
+++ b/src/components/account/Maintenance.tsx
@@ -28,7 +28,7 @@ export function Maintenance() {
       setOpenDeleteDialog(false);
     } catch (error) {
       console.error('Error deleting photos:', error);
-      alert('Failed to delete photos: ' + error);
+      toast.error('Failed to delete photos');
     } finally {
       setDeleting(false);
     }

--- a/src/components/album/AlbumGrid.tsx
+++ b/src/components/album/AlbumGrid.tsx
@@ -114,7 +114,7 @@ export function AlbumGrid() {
       setAlbums(albumList);
     } catch (error) {
       console.error('Error fetching albums:', error);
-      toast.error('Failed to fetch albums: ' + error);
+      toast.error('Failed to fetch albums');
     }
   };
 
@@ -126,7 +126,7 @@ export function AlbumGrid() {
         setAlbums(albumList);
       } catch (error) {
         console.error('Error fetching albums:', error);
-        toast.error('Failed to fetch albums: ' + error);
+        toast.error('Failed to fetch albums');
       }
     }
     loadAlbums();
@@ -158,7 +158,7 @@ export function AlbumGrid() {
         setSelectedAlbum(undefined);
       } catch (error) {
         console.error('Error creating album:', error);
-        toast.error('Failed to create album: ' + error);
+        toast.error('Failed to create album');
       }
     }
     setShowAdd(false);
@@ -171,7 +171,7 @@ export function AlbumGrid() {
         await fetchAlbums();
       } catch (error) {
         console.error('Error updating album:', error);
-        toast.error('Failed to update album: ' + error);
+        toast.error('Failed to update album');
       }
     }
     setShowEdit(false);
@@ -185,7 +185,7 @@ export function AlbumGrid() {
         setSelectedAlbum(undefined);
       } catch (error) {
         console.error('Error deleting album:', error);
-        toast.error('Failed to delete album: ' + error);
+        toast.error('Failed to delete album');
       }
     }
     setShowDelete(false);

--- a/src/components/album/AlbumGrid.tsx
+++ b/src/components/album/AlbumGrid.tsx
@@ -114,7 +114,7 @@ export function AlbumGrid() {
       setAlbums(albumList);
     } catch (error) {
       console.error('Error fetching albums:', error);
-      toast.error('Failed to fetch albums');
+      toast.error('Failed to fetch albums: ' + error);
     }
   };
 
@@ -126,7 +126,7 @@ export function AlbumGrid() {
         setAlbums(albumList);
       } catch (error) {
         console.error('Error fetching albums:', error);
-        toast.error('Failed to fetch albums');
+        toast.error('Failed to fetch albums: ' + error);
       }
     }
     loadAlbums();
@@ -158,7 +158,7 @@ export function AlbumGrid() {
         setSelectedAlbum(undefined);
       } catch (error) {
         console.error('Error creating album:', error);
-        toast.error('Failed to create album');
+        toast.error('Failed to create album: ' + error);
       }
     }
     setShowAdd(false);
@@ -171,7 +171,7 @@ export function AlbumGrid() {
         await fetchAlbums();
       } catch (error) {
         console.error('Error updating album:', error);
-        toast.error('Failed to update album');
+        toast.error('Failed to update album: ' + error);
       }
     }
     setShowEdit(false);
@@ -185,7 +185,7 @@ export function AlbumGrid() {
         setSelectedAlbum(undefined);
       } catch (error) {
         console.error('Error deleting album:', error);
-        toast.error('Failed to delete album');
+        toast.error('Failed to delete album: ' + error);
       }
     }
     setShowDelete(false);

--- a/src/components/album/AlbumGrid.tsx
+++ b/src/components/album/AlbumGrid.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Album } from '@/lib/api/types';
 import { albumsService } from '@/lib/api/services';
 import { useMPContext } from '@/context/MPContext';
+import { useToast } from '@/context/ToastContext';
 import { AlbumAddDialog } from './AlbumAddDialog';
 import { AlbumEditDialog } from './AlbumEditDialog';
 import { AlbumDeleteDialog } from './AlbumDeleteDialog';
@@ -100,6 +101,7 @@ function AlbumCard({ album, isAdmin, onEdit, onDelete }: AlbumCardProps) {
 
 export function AlbumGrid() {
   const { isUser } = useMPContext();
+  const toast = useToast();
   const [albums, setAlbums] = useState<Album[]>([]);
   const [selectedAlbum, setSelectedAlbum] = useState<Album | undefined>(undefined);
   const [showAdd, setShowAdd] = useState(false);
@@ -112,7 +114,7 @@ export function AlbumGrid() {
       setAlbums(albumList);
     } catch (error) {
       console.error('Error fetching albums:', error);
-      alert('Failed to fetch albums');
+      toast.error('Failed to fetch albums');
     }
   };
 
@@ -124,7 +126,7 @@ export function AlbumGrid() {
         setAlbums(albumList);
       } catch (error) {
         console.error('Error fetching albums:', error);
-        alert('Failed to fetch albums');
+        toast.error('Failed to fetch albums');
       }
     }
     loadAlbums();
@@ -156,7 +158,7 @@ export function AlbumGrid() {
         setSelectedAlbum(undefined);
       } catch (error) {
         console.error('Error creating album:', error);
-        alert('Failed to create album');
+        toast.error('Failed to create album');
       }
     }
     setShowAdd(false);
@@ -169,7 +171,7 @@ export function AlbumGrid() {
         await fetchAlbums();
       } catch (error) {
         console.error('Error updating album:', error);
-        alert('Failed to update album');
+        toast.error('Failed to update album');
       }
     }
     setShowEdit(false);
@@ -183,7 +185,7 @@ export function AlbumGrid() {
         setSelectedAlbum(undefined);
       } catch (error) {
         console.error('Error deleting album:', error);
-        alert('Failed to delete album');
+        toast.error('Failed to delete album');
       }
     }
     setShowDelete(false);

--- a/src/components/camera/UpdateCameraDialog.tsx
+++ b/src/components/camera/UpdateCameraDialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { Camera } from '@/lib/api/types';
 import { camerasService } from '@/lib/api/services';
+import { useToast } from '@/context/ToastContext';
 import { Dialog } from '@/components/Dialog';
 import { Button } from '@/components/Button';
 import { Select } from '@/components/Select';
@@ -16,6 +17,7 @@ interface UpdateCameraDialogProps {
 }
 
 export function UpdateCameraDialog({ camera, open, onClose, onUpdate }: UpdateCameraDialogProps) {
+  const toast = useToast();
   const [formData, setFormData] = useState<Camera>(camera);
   const [updating, setUpdating] = useState(false);
 
@@ -53,7 +55,7 @@ export function UpdateCameraDialog({ camera, open, onClose, onUpdate }: UpdateCa
       onClose();
     } catch (error) {
       console.error('Error updating camera:', error);
-      alert('Failed to update camera: ' + error);
+      toast.error('Failed to update camera');
     } finally {
       setUpdating(false);
     }


### PR DESCRIPTION
## Janitor Agent - Replace alert() with useToast in error handlers

Several components use the native browser `alert()` for error feedback instead of the app's existing `useToast` hook, resulting in inconsistent UX and blocking UI. All error and success messages should go through the toast system.

### Changes

- src/components/album/AlbumGrid.tsx: Import `useToast` and replace every `alert('Failed to fetch albums')`, `alert('Failed to create album')`, `alert('Failed to update album')`, and `alert('Failed to delete album')` call with `toast.error(...)`. Add `const toast = useToast();` inside `AlbumGrid`.
- src/components/camera/UpdateCameraDialog.tsx: Import `useToast`, add `const toast = useToast();` inside `UpdateCameraDialog`, and replace `alert('Failed to update camera: ' + error)` with `toast.error('Failed to update camera')`.
- src/components/account/GoogleDrive.tsx: Import `useToast`, add `const toast = useToast();`, and replace all `alert(...)` calls (for auth error, folder set error, unexpected job state, and download error) with appropriate `toast.error(...)` or `toast.warning(...)` calls.
- src/components/account/Maintenance.tsx: Import `useToast`, add `const toast = useToast();`, and replace the `alert('Successfully deleted ...')` success call with `toast.success(...)` and `alert('Failed to delete photos: ' + error)` with `toast.error('Failed to delete photos')`.

---
*Created by [janitor-agent](https://github.com/msvens/janitor-agent)*