### PR TITLE
Add Google OAuth login path alongside password login

### DIFF
--- a/CLAUDE_LOGIN_HANDOFF.md
+++ b/CLAUDE_LOGIN_HANDOFF.md
@@ -1,0 +1,108 @@
+# Admin Login: Add Google OAuth Path
+
+## Context
+
+The mphotos backend now supports two admin-login methods, picked by a server-side config setting:
+
+- `password` — the existing username/password form (unchanged)
+- `google` — Sign in with Google, gated by an email allowlist on the backend
+
+The UI does **not** know or care which method is configured. It asks the backend, then renders the appropriate widget.
+
+The session cookie that establishes admin status is identical in both cases. So once login completes — by either method — the rest of the app behaves exactly as it does today. Only the login screen needs to change.
+
+## What you need to build
+
+### 1. New endpoint to query: `GET /api/auth/method`
+
+Returns:
+
+```json
+{ "data": { "method": "google" } }
+```
+
+or
+
+```json
+{ "data": { "method": "password" } }
+```
+
+(Note: backend wraps responses in `{ "data": ... }` — same envelope as other endpoints.)
+
+Call this on mount of the login page. Cache the result for the session — it doesn't change at runtime.
+
+### 2. Branch the login UI on the result
+
+- `"password"` → render the existing username/password form. **No change** — this is the current flow, which posts to `PUT /api/login` and gets back the session cookie.
+- `"google"` → render a "Sign in with Google" button.
+
+### 3. Google button click handler
+
+```js
+window.location.href = "/api/login/google"
+```
+
+**Critical: this must be a full-page navigation, not a fetch/XHR.** OAuth flows redirect through Google's domain, which can't happen inside an XHR. Use `window.location.href = ...` or a plain `<a href="/api/login/google">` — never `fetch()`.
+
+### 4. After Google redirects back
+
+The flow is:
+1. User clicks button → browser navigates to `/api/login/google`
+2. Backend redirects to Google → user consents
+3. Google redirects to `/api/auth/login/callback` (backend)
+4. Backend verifies email allowlist, sets the session cookie, then **302 redirects back to `/`** (configurable via `auth.google.uiRedirectPath` on the backend; currently set to `/account`)
+
+When the user lands back on the UI, the session cookie is already set. Treat it identically to a successful password login — re-fetch logged-in state from `/api/loggedin` (or whatever the existing app does on mount) and route to the admin area.
+
+### 5. Error handling
+
+If the Google flow fails, the backend redirects to `<uiRedirectPath>?error=<reason>` (currently `/account?error=...`). Possible reasons:
+
+| `error` value          | Meaning                                              | Suggested user message                                          |
+|------------------------|------------------------------------------------------|-----------------------------------------------------------------|
+| `unauthorized_email`   | Email not in the backend's allowlist (or unverified) | "This Google account is not authorized for this site."          |
+| `invalid_state`        | CSRF state cookie missing/mismatched/expired         | "Login session expired. Please try again."                      |
+| `exchange_failed`      | OAuth code exchange or userinfo fetch failed         | "Could not complete sign-in with Google. Please try again."     |
+
+On the login page, read the `error` URL query parameter on mount and surface a message if present. Clear the param from the URL after reading it (e.g. `history.replaceState`) so a refresh doesn't keep showing the error.
+
+### 6. Already-logged-in case
+
+If the user lands on the login page but is already authenticated (cookie still valid), redirect them to the admin area. The existing UI almost certainly already does this — just make sure it still works for the Google-method case (it should; the cookie is identical).
+
+### 7. Logout — unchanged
+
+`GET /api/logout` clears the session cookie regardless of how the user logged in. No UI change needed.
+
+Note: this does **not** sign the user out of Google globally. Standard and intentional.
+
+## What the UI does NOT need to know
+
+- The email allowlist (lives on the backend).
+- OAuth client ID, scopes, redirect URIs (all backend).
+- Whether the operator changed `auth.method` (just call `/api/auth/method` again).
+- Any token storage. The backend handles everything; the UI only ever sees the session cookie set automatically.
+
+## Backend endpoints reference (read-only summary)
+
+| Method | Path                        | Purpose                                                       |
+|--------|-----------------------------|---------------------------------------------------------------|
+| GET    | `/api/auth/method`          | Returns `{"method": "password" \| "google"}` (public)         |
+| PUT    | `/api/login`                | Existing password login. Returns 405 when method=google.      |
+| GET    | `/api/login/google`         | Starts the Google OAuth login flow (full-page redirect target)|
+| GET    | `/api/auth/login/callback`  | Google's callback — UI does not call this directly             |
+| GET    | `/api/logout`               | Clears session cookie (unchanged)                             |
+| GET    | `/api/loggedin`             | Existing endpoint to check auth status (unchanged)            |
+
+## Local dev
+
+- Backend runs on `:8050`, fronted by nginx on `:8060` which routes `/api/*` to the backend and everything else to this UI app.
+- All requests are same-origin via nginx, so no CORS / SameSite cookie complications.
+- `auth.method` is currently set to `google` in the local config. Flip the backend config and restart to test the password path again.
+
+## Suggested test plan
+
+1. `curl http://localhost:8060/api/auth/method` returns `{"data":{"method":"google"}}` — already verified.
+2. With method=google: visit the login page → see Google button → click → Google consent → redirect back → lands logged in.
+3. Force the error path: temporarily change the backend's `auth.google.allowedEmails` to a different address, restart, retry the flow → should land on `/?error=unauthorized_email` and show a message.
+4. Flip backend to method=password → reload login page → see the old form, which still works.

--- a/src/components/account/Login.tsx
+++ b/src/components/account/Login.tsx
@@ -1,25 +1,75 @@
 'use client';
 
-import { useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useMPContext } from '@/context/MPContext';
 import { Divider } from "@/components/Divider";
 import { Button } from "@/components/Button";
+import { authService, AuthMethod } from '@/lib/api/services/auth';
+import { API_ENDPOINTS } from '@/lib/api/config';
+
+type LoadStatus = 'loading' | 'ready' | 'failed';
+
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  unauthorized_email: 'This Google account is not authorized for this site.',
+  invalid_state: 'Login session expired. Please try again.',
+  exchange_failed: 'Could not complete sign-in with Google. Please try again.',
+};
 
 export function Login() {
+  return (
+    <Suspense fallback={<LoginFallback />}>
+      <LoginContent />
+    </Suspense>
+  );
+}
+
+function LoginFallback() {
+  return (
+    <div className="space-y-8 max-w-md mx-auto text-center">
+      <h1 className="text-2xl font-light mb-4">Login</h1>
+      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-gray-900 dark:border-white mx-auto"></div>
+    </div>
+  );
+}
+
+function LoginContent() {
   const { login } = useMPContext();
+  const searchParams = useSearchParams();
+
+  const [status, setStatus] = useState<LoadStatus>('loading');
+  const [authMethod, setAuthMethod] = useState<AuthMethod | null>(null);
+  const [oauthError, setOauthError] = useState('');
+
   const [password, setPassword] = useState('');
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [loginError, setLoginError] = useState('');
 
+  useEffect(() => {
+    const errorParam = searchParams.get('error');
+    if (errorParam) {
+      setOauthError(OAUTH_ERROR_MESSAGES[errorParam] ?? 'Sign-in failed. Please try again.');
+      window.history.replaceState(null, '', '/account');
+    }
+
+    authService.getAuthMethod()
+      .then((method) => {
+        setAuthMethod(method);
+        setStatus('ready');
+      })
+      .catch(() => {
+        setStatus('failed');
+      });
+  }, [searchParams]);
+
   const handleLogin = async () => {
     if (!password.trim()) return;
-    
+
     setIsLoggingIn(true);
     setLoginError('');
-    
+
     try {
       await login(password);
-      // Context will automatically update the UI
     } catch {
       setLoginError('Incorrect password');
     } finally {
@@ -32,6 +82,11 @@ export function Login() {
     if (loginError) setLoginError('');
   };
 
+  const handleGoogleLogin = () => {
+    // Full-page navigation is required for OAuth — never use fetch/XHR here.
+    window.location.href = API_ENDPOINTS.loginGoogle;
+  };
+
   return (
     <div className="space-y-8 max-w-md mx-auto">
       <div className="text-center">
@@ -42,37 +97,74 @@ export function Login() {
       <Divider />
 
       <div className="space-y-6">
-        {loginError && (
+        {oauthError && (
           <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
-            <p className="text-red-500 text-sm">{loginError}</p>
+            <p className="text-red-500 text-sm">{oauthError}</p>
           </div>
         )}
 
-        <div>
-          <label className="block text-sm font-medium mb-2 text-gray-900 dark:text-white">
-            Password
-          </label>
-          <input
-            type="password"
-            value={password}
-            onChange={handlePasswordChange}
-            onKeyPress={(e) => e.key === 'Enter' && handleLogin()}
-            className="w-full p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent text-gray-900 dark:text-white placeholder:text-gray-600 dark:placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            placeholder="Enter your password"
-            disabled={isLoggingIn}
-          />
-        </div>
+        {status === 'loading' && (
+          <div className="text-center py-4">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-gray-900 dark:border-white mx-auto mb-2"></div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">Loading…</p>
+          </div>
+        )}
 
-        <Button
-          onClick={handleLogin}
-          color="primary"
-          variant="outlined"
-          fullWidth
-          disabled={isLoggingIn || !password.trim()}
-          className="h-12"
-        >
-          {isLoggingIn ? 'Logging in...' : 'Login'}
-        </Button>
+        {status === 'failed' && (
+          <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+            <p className="text-red-500 text-sm">
+              Unable to determine login method. Please reload the page or contact the administrator.
+            </p>
+          </div>
+        )}
+
+        {status === 'ready' && authMethod === 'password' && (
+          <>
+            {loginError && (
+              <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                <p className="text-red-500 text-sm">{loginError}</p>
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm font-medium mb-2 text-gray-900 dark:text-white">
+                Password
+              </label>
+              <input
+                type="password"
+                value={password}
+                onChange={handlePasswordChange}
+                onKeyPress={(e) => e.key === 'Enter' && handleLogin()}
+                className="w-full p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-transparent text-gray-900 dark:text-white placeholder:text-gray-600 dark:placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="Enter your password"
+                disabled={isLoggingIn}
+              />
+            </div>
+
+            <Button
+              onClick={handleLogin}
+              color="primary"
+              variant="outlined"
+              fullWidth
+              disabled={isLoggingIn || !password.trim()}
+              className="h-12"
+            >
+              {isLoggingIn ? 'Logging in...' : 'Login'}
+            </Button>
+          </>
+        )}
+
+        {status === 'ready' && authMethod === 'google' && (
+          <Button
+            onClick={handleGoogleLogin}
+            color="primary"
+            variant="outlined"
+            fullWidth
+            className="h-12"
+          >
+            Sign in with Google
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/lib/api/__tests__/services/auth.test.ts
+++ b/src/lib/api/__tests__/services/auth.test.ts
@@ -60,4 +60,25 @@ describe('authService', () => {
       expect(await authService.isLoggedIn()).toBe(false);
     });
   });
+
+  describe('getAuthMethod', () => {
+    it('returns "password" when API responds with password method', async () => {
+      vi.mocked(api.get).mockResolvedValue({ method: 'password' });
+      const result = await authService.getAuthMethod();
+      expect(api.get).toHaveBeenCalledWith(API_ENDPOINTS.authMethod);
+      expect(result).toBe('password');
+    });
+
+    it('returns "google" when API responds with google method', async () => {
+      vi.mocked(api.get).mockResolvedValue({ method: 'google' });
+      const result = await authService.getAuthMethod();
+      expect(api.get).toHaveBeenCalledWith(API_ENDPOINTS.authMethod);
+      expect(result).toBe('google');
+    });
+
+    it('propagates errors when the endpoint fails', async () => {
+      vi.mocked(api.get).mockRejectedValue(new Error('Network error'));
+      await expect(authService.getAuthMethod()).rejects.toThrow('Network error');
+    });
+  });
 });

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -6,6 +6,8 @@ export const API_ENDPOINTS = {
     login: '/api/login',
     logout: '/api/logout',
     loggedIn: '/api/loggedin',
+    authMethod: '/api/auth/method',
+    loginGoogle: '/api/login/google',
 
     // User and config
     user: '/api/user',

--- a/src/lib/api/services/auth.ts
+++ b/src/lib/api/services/auth.ts
@@ -9,10 +9,17 @@ export interface LoginRequest {
   password: string;
 }
 
+export type AuthMethod = 'password' | 'google';
+
+export interface AuthMethodResponse {
+  method: AuthMethod;
+}
+
 export interface AuthService {
   login(password: string): Promise<AuthUser>;
   logout(): Promise<AuthUser>;
   isLoggedIn(): Promise<boolean>;
+  getAuthMethod(): Promise<AuthMethod>;
 }
 
 export const authService: AuthService = {
@@ -34,5 +41,10 @@ export const authService: AuthService = {
     } catch {
       return false;
     }
+  },
+
+  async getAuthMethod(): Promise<AuthMethod> {
+    const response = await api.get<AuthMethodResponse>(API_ENDPOINTS.authMethod);
+    return response.method;
   },
 };


### PR DESCRIPTION
## Summary
- New `GET /api/auth/method` is queried on mount of the login page; UI branches between the existing password form and a "Sign in with Google" button based on the response.
- Google flow uses a full-page navigation to `/api/login/google` (required for OAuth — never `fetch`). Backend redirects back to `/account`; existing MPContext.refreshAuth() picks up the session cookie identically to the password flow.
- OAuth error reasons (`unauthorized_email`, `invalid_state`, `exchange_failed`) read from `?error=` are mapped to user-friendly messages and cleared from the URL via `history.replaceState` so a refresh doesn't re-show them.
- If `/api/auth/method` itself fails, the UI shows an explicit error rather than silently falling back to a password form that may not be configured backend-side.
- Adds 3 vitest cases for `authService.getAuthMethod()`.
- Includes `CLAUDE_LOGIN_HANDOFF.md` — the spec from the backend team for reference.

## Test plan
- [x] `pnpm check` (typecheck, lint, tests, build) passes — 99/99 tests green
- [x] Manual: method=google → see Google button → sign in → land back on /account logged in
- [x] Manual: logout → login again works (cookie behaves identically to password flow)
- [ ] Manual: error path — set unauthorized email in backend allowlist → see "This Google account is not authorized for this site"
- [ ] Manual: flip backend `auth.method` to `password` → reload `/account` → existing form works as before
- [ ] Manual: stop backend or break `/api/auth/method` → see "Unable to determine login method" message